### PR TITLE
skip mvn doc creation if already PURL exists

### DIFF
--- a/src/models/maven.py
+++ b/src/models/maven.py
@@ -61,29 +61,30 @@ class ModelLibrary(Document):
             self.purl = purl.to_string()
             l.debug("set PURL as {}".format(self.purl))
 
-        # if mvn doc already exists, dont create new.
-        l.debug("Search for PURL if already exists: {}".format(self.purl))
-        q = Q({
-                "bool": {
-                    "must": [
-                    {
-                        "match_phrase": {
-                        "purl": self.purl
+        l.debug("PURL: {}".format(self.purl))
+        if not hasattr(self.meta, 'id'):
+            # no 'id' set, then its a create call not update call
+            # so if mvn doc already exists for this PURL, dont create new.
+            l.debug("Search for PURL if already exists: {}".format(self.purl))
+            q = Q({
+                    "bool": {
+                        "must": [
+                        {
+                            "match_phrase": {
+                            "purl": self.purl
+                            }
                         }
+                        ]
                     }
-                    ]
-                }
-                })
-        s = ModelLibrary.search().query(q)
-        searchResponse = s.execute()
-        l.debug(s.to_dict())
-        l.debug("Search by PURL hit count : {}".format(str(searchResponse.hits.total.value)))
-        for hits in searchResponse:
-            l.debug("ID {}, PURL {}".format(hits.meta.id, hits.purl))
-        if searchResponse.hits.total.value > 0 :
-            l.info("MVN doc with PURL {} already exists. Skipping creation.".format(self.purl))
-            resp = "exists"
-            return resp        
+                    })
+            s = ModelLibrary.search().query(q)
+            searchResponse = s.execute()
+            l.debug(s.to_dict())
+            l.debug("Search by PURL hit count : {}".format(str(searchResponse.hits.total.value)))
+            if searchResponse.hits.total.value > 0 :
+                l.info("MVN doc with PURL {} already exists. Skipping creation.".format(self.purl))
+                resp = "exists"
+                return resp        
 
 
         l.info("Calling ES:save API...")

--- a/src/rpc/mvndocservice.py
+++ b/src/rpc/mvndocservice.py
@@ -42,8 +42,8 @@ class MvnDocServiceServicer(models.protobuf.primrose_pb2_grpc.MavenDocServiceSer
             l.critical("Error on ES:save call.")
             l.debug(e)
         l.info("ES create call returned : {}".format(resp))
-        return models.protobuf.primrose_pb2.Status(code=0 if str(resp) == "created" or 
-        str(resp) == "updated" else 1, msg=str(resp))
+        return models.protobuf.primrose_pb2.Status(code=0 if resp == "created" or 
+        resp == "updated" or resp == "exists" else 1, msg=resp)
 
     def Delete(self, request, context):
         l = Logger.getLogger(__name__)


### PR DESCRIPTION
- On MVN: save checks for doc if already PURL exists, if then skips. 
- Check is only for create operation, ie if hasattr 'id'